### PR TITLE
Remove the deprecated flag --asynchronous

### DIFF
--- a/assignment4/README.md
+++ b/assignment4/README.md
@@ -5,6 +5,7 @@
 **Changelog**:
 
 ```diff
+- Nov 25: Remove deprecated flag --asynchronous.
 + Nov 22: Update installation guide. Update examplar evaluate script.
 + Nov 22: Add box2d installation guide.
 + Nov 15: Change the installation instruction on MetaDrive. Some windows user experience error if install via pip git+.

--- a/assignment4/assignment4.ipynb
+++ b/assignment4/assignment4.ipynb
@@ -359,7 +359,6 @@
     "  --algo PPO \\\n",
     "  --log-dir MetaDriveEasy \\\n",
     "  --num-envs 10 \\\n",
-    "  --asynchronous \\\n",
     "  --max-steps 500000"
    ]
   },

--- a/assignment4/exp.sh
+++ b/assignment4/exp.sh
@@ -1,4 +1,4 @@
 # Example script to launch formal experiment.
 num=1
 echo Start Training ${num} Environments
-CUDA_VISIBLE_DEVICES="" nohup python train.py --env-id MetaDrive-Tut-${num}Env-v0 --num-steps 2000 --num-envs 10 --asynchronous --algo PPO --log-dir metadrive_${num}_env > metadrive_${num}_env.log 2>&1 &
+CUDA_VISIBLE_DEVICES="" nohup python train.py --env-id MetaDrive-Tut-${num}Env-v0 --num-steps 2000 --num-envs 10 --algo PPO --log-dir metadrive_${num}_env > metadrive_${num}_env.log 2>&1 &

--- a/assignment4/exp_search_lr.sh
+++ b/assignment4/exp_search_lr.sh
@@ -1,4 +1,4 @@
 # Example script to grid search some hyper parameters.
 for lr in 1e-4 5e-5 1e-5 5e-6; do
-  CUDA_VISIBLE_DEVICES="" nohup python train.py --env-id MetaDrive-Tut-10Env-v0 --num-epoch 5 --num-steps 2000 --num-envs 10 --asynchronous --algo PPO --log-dir search_lr_${lr} --lr ${lr} >search_lr_${lr}.log 2>&1 &
+  CUDA_VISIBLE_DEVICES="" nohup python train.py --env-id MetaDrive-Tut-10Env-v0 --num-epoch 5 --num-steps 2000 --num-envs 10 --algo PPO --log-dir search_lr_${lr} --lr ${lr} >search_lr_${lr}.log 2>&1 &
 done


### PR DESCRIPTION
Now we default to use `asynchronous` mode. You can disable parallel sampling by specifying the config `--synchronous`.